### PR TITLE
fix(windows): UTF-8 stdout/stderr in embedded Python blocks (#24)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -938,6 +938,14 @@ import json
 import sys
 import os
 
+# Fix #24 — Force UTF-8 stdout/stderr for Windows cp1252 compatibility
+if sys.platform == 'win32':
+    try:
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    except (AttributeError, Exception):
+        pass
+
 try:
     settings_file = '${settings_file}'
 
@@ -1045,7 +1053,16 @@ copy_bundled_skills() {
     if command -v python3 >/dev/null 2>&1; then
         local stripped_count
         stripped_count=$(TARGET_DIR="${TARGET_DIR}" python3 << 'STRIP_FM'
-import os, glob
+import os, glob, sys
+
+# Fix #24 — Force UTF-8 stdout/stderr for Windows cp1252 compatibility
+if sys.platform == 'win32':
+    try:
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    except (AttributeError, Exception):
+        pass
+
 skills_dir = os.path.join(os.environ.get('TARGET_DIR', '.'), '.claude/skills')
 count = 0
 for md in glob.glob(os.path.join(skills_dir, '*/SKILL.md')):
@@ -1290,6 +1307,14 @@ import subprocess
 import os
 import sys
 import shutil
+
+# Fix #24 — Force UTF-8 stdout/stderr for Windows cp1252 compatibility
+if sys.platform == 'win32':
+    try:
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    except (AttributeError, Exception):
+        pass
 
 profile_path = os.environ.get('profile_path', '')
 target_dir = os.environ.get('TARGET_DIR', '')
@@ -1670,6 +1695,14 @@ configure_agents() {
 import json
 import os
 import sys
+
+# Fix #24 — Force UTF-8 stdout/stderr for Windows cp1252 compatibility
+if sys.platform == 'win32':
+    try:
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    except (AttributeError, Exception):
+        pass
 
 profile_path = os.environ.get('profile_path', '')
 target_dir = os.environ.get('TARGET_DIR', '')
@@ -2254,7 +2287,17 @@ create_settings_json() {
         log_info "settings.json already exists — adding hooks and metadata..."
         if command -v python3 >/dev/null 2>&1; then
             TARGET_DIR="${TARGET_DIR}" python3 << 'MERGE_SETTINGS'
-import json, os
+import json, os, sys
+
+# Fix #24 — Force UTF-8 stdout/stderr for Windows cp1252 compatibility
+# Prevents UnicodeEncodeError when printing emojis (✅, ✓) on Windows default codepage
+if sys.platform == 'win32':
+    try:
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    except (AttributeError, Exception):
+        pass
+
 target_dir = os.environ.get('TARGET_DIR', '')
 settings_file = os.path.join(target_dir, '.claude/settings.json')
 try:

--- a/setup-wizard.sh
+++ b/setup-wizard.sh
@@ -213,7 +213,15 @@ update_settings_json() {
     fi
 
     python3 << PYEOF
-import json, os
+import json, os, sys
+
+# Fix #24 — Force UTF-8 stdout/stderr for Windows cp1252 compatibility
+if sys.platform == 'win32':
+    try:
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    except (AttributeError, Exception):
+        pass
 
 settings_path = "${SETTINGS_FILE}"
 var_name = "${var_name}"


### PR DESCRIPTION
Closes #24

## Summary
Fixes UnicodeEncodeError in 6 embedded Python heredoc blocks when running on Windows with default codepage cp1252.

## Root cause
Embedded Python blocks in install.sh / setup-wizard.sh use `print()` with emoji characters (✅, ✓). On Windows, `sys.stdout` defaults to codepage cp1252 which cannot encode characters outside Latin-1. Python raises `UnicodeEncodeError` and aborts the block.

## Fix
Add defensive UTF-8 reconfiguration at the top of each Python block:

```python
if sys.platform == 'win32':
    try:
        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
    except (AttributeError, Exception):
        pass
```

- **`errors='replace'`** — fallback for terminals without UTF-8 (emojis become `?` instead of crashing)
- **Platform check** — no-op on Linux/macOS
- **try/except** — handles Python <3.7 where reconfigure() doesn't exist

## Affected blocks
| File | Line | Block |
|---|---|---|
| install.sh | 936 | PYTHON_SCRIPT (nano-banana settings) |
| install.sh | 1055 | STRIP_FM (frontmatter strip) |
| install.sh | 1304 | MCP_INSTALLER_BLOCK |
| install.sh | 1694 | CONFIGURE_AGENTS_BLOCK |
| install.sh | 2289 | MERGE_SETTINGS (origin of reported error) |
| setup-wizard.sh | 215 | PYEOF |

## Verification
- ✅ `bash -n install.sh` passes
- ✅ `bash -n setup-wizard.sh` passes
- ✅ Pattern is idempotent (no harm if applied twice)
- ✅ Compatible with Bash 3.2+

## Test plan
- [x] Linux: no behavior change (platform check skips)
- [x] macOS: no behavior change
- [x] Windows: emojis print correctly OR fallback to `?` without crashing

## Related
- Issue #11 (cross-platform Python hooks) — related but different scope
- Issue #16 (closed in v4.0) — addressed hooks/ but not embedded Python in install.sh