### PR TITLE
docs: comprehensive INSTALL.md, NotebookLM tutorial kit, v4.0.1 README updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,353 @@
+# Installing Devlmer Ecosystem Engine (DEE)
+
+> **Quick Start:** copy-paste one of the methods below. Takes 60 seconds.
+
+---
+
+## Choose your installation method
+
+| Method | For whom | Platform | Time |
+|---|---|---|---|
+| **[1. One-liner curl](#method-1--one-liner-curl-recommended)** | First-time users, casual installs | macOS / Linux | 30s |
+| **[2. git clone](#method-2--git-clone-recommended-for-developers)** | Developers, contributors, power users | All platforms | 1m |
+| **[3. ZIP download](#method-3--zip-download-windows-without-git)** | Windows users without Git | Windows | 2m |
+| **[4. Dry-run preview](#method-4--dry-run-preview-cautious-users)** | Cautious users, CI pipelines | All platforms | 1m |
+
+---
+
+## Method 1 — One-liner curl (RECOMMENDED)
+
+The fastest way to install DEE in any project:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/install-cli.sh | bash
+```
+
+**What this does:**
+1. Downloads `install-cli.sh`
+2. Clones DEE temporarily to `/tmp/dee-install/`
+3. Asks where to install (default: current directory)
+4. Sets up `.claude/` with skills, commands, hooks, and config
+
+**Requirements:** macOS 10.14+, Linux (Ubuntu 20+), or Windows with Git Bash.
+
+---
+
+## Method 2 — git clone (recommended for developers)
+
+If you have Git installed, this is the most flexible method:
+
+```bash
+# Clone DEE to a temporary directory
+git clone https://github.com/Soyelijah/devlmer-ecosystem-engine.git /tmp/dee-install
+
+# Install in your project
+bash /tmp/dee-install/install.sh /path/to/your/project
+
+# Optional: clean up
+rm -rf /tmp/dee-install
+```
+
+**Replace `/path/to/your/project`** with your actual project directory.
+
+**Examples:**
+```bash
+# macOS / Linux
+bash /tmp/dee-install/install.sh ~/Documents/my-app
+
+# Windows (Git Bash)
+bash /tmp/dee-install/install.sh "C:/Users/YourName/Documents/my-app"
+
+# Current directory
+bash /tmp/dee-install/install.sh .
+```
+
+---
+
+## Method 3 — ZIP download (Windows without Git)
+
+If you don't have Git installed:
+
+```bash
+# 1. Download DEE as ZIP
+curl -L -o dee.zip https://github.com/Soyelijah/devlmer-ecosystem-engine/archive/refs/heads/main.zip
+
+# 2. Extract
+unzip dee.zip
+
+# 3. Install
+cd devlmer-ecosystem-engine-main
+bash install.sh "C:/path/to/your/project"
+```
+
+Requires `bash` (comes with Git Bash on Windows).
+
+---
+
+## Method 4 — Dry-run preview (cautious users)
+
+**NEW in v4.0.1:** Preview exactly what DEE would do BEFORE making any changes.
+
+```bash
+# Clone first
+git clone https://github.com/Soyelijah/devlmer-ecosystem-engine.git /tmp/dee-install
+
+# Dry-run: shows predicted changes, modifies NOTHING
+bash /tmp/dee-install/install.sh /path/to/your/project --dry-run --non-interactive
+
+# If you like the preview, run for real:
+bash /tmp/dee-install/install.sh /path/to/your/project
+```
+
+**Sample dry-run output:**
+```
+[DRY-RUN] create /your-project/.claude/
+[DRY-RUN] create /your-project/.claude/skills/ (64 skill(s))
+[DRY-RUN] create /your-project/.claude/commands/ (8 slash command(s))
+[DRY-RUN] modify /your-project/CLAUDE.md (append DEE footer)
+... 19 total predicted operations
+
+DRY-RUN SUMMARY
+  + Would CREATE  : 16 item(s)
+  ~ Would MODIFY  : 3 item(s)
+  - Would DELETE  : 0 item(s)
+```
+
+`--dry-run` is guaranteed read-only — your project stays untouched until you run without the flag.
+
+---
+
+## Requirements
+
+Before installing, ensure you have:
+
+| Tool | Minimum version | Check |
+|---|---|---|
+| **Node.js** | 18+ | `node --version` |
+| **Python** | 3.8+ | `python3 --version` |
+| **Git** | 2.x+ | `git --version` |
+| **bash** | 4.x+ (or 3.2 macOS) | `bash --version` |
+| **Claude Code** or **Cowork** | latest | — |
+
+### Install missing dependencies
+
+**macOS:**
+```bash
+brew install node python3 git
+```
+
+**Linux (Ubuntu/Debian):**
+```bash
+sudo apt update && sudo apt install -y nodejs npm python3 python3-pip git
+```
+
+**Windows:**
+- Node.js: https://nodejs.org/
+- Python: https://www.python.org/downloads/
+- Git for Windows (includes Git Bash): https://git-scm.com/download/win
+
+---
+
+## Post-install security checklist (IMPORTANT)
+
+After any installation method, **immediately** add API key configs to your project's `.gitignore`:
+
+```bash
+cd /path/to/your/project
+
+cat >> .gitignore <<'EOF'
+
+# DEE local API keys — never commit
+.claude/config/nano-banana-config.json
+.claude/config/github-config.json
+.claude/PROJECT_PROFILE.json
+.claude/logs/
+.claude/.dee-backup-*/
+EOF
+```
+
+This prevents your `GEMINI_API_KEY` and `GITHUB_TOKEN` from accidentally being committed to a public repository.
+
+---
+
+## First-time setup (after install)
+
+1. **Open your project in Claude Code or Cowork**
+2. **Run health check:**
+   ```
+   /dee-doctor
+   ```
+3. **View what's installed:**
+   ```
+   /dee-status
+   ```
+4. **Take the interactive tour:**
+   ```
+   /dee-demo
+   ```
+5. **Configure API keys** (optional, only if you want image generation):
+   - Edit `.claude/config/nano-banana-config.json`
+   - Set your `GEMINI_API_KEY` (get one at https://aistudio.google.com/apikey)
+
+---
+
+## Updating an existing installation
+
+DEE includes an `update.sh` script that preserves your local config:
+
+```bash
+cd /path/to/devlmer-ecosystem-engine  # or clone fresh
+git pull origin main
+bash update.sh /path/to/your/project
+```
+
+`update.sh` automatically backs up:
+- `mcp-env-setup.sh`
+- `settings.json`
+- `PROJECT_PROFILE.json`
+- `CLAUDE.md`
+
+And updates skills, commands, hooks, and scripts.
+
+---
+
+## Installation flags reference
+
+```bash
+bash install.sh /path/to/project [OPTIONS]
+```
+
+| Flag | Description |
+|---|---|
+| `--help` | Show help |
+| `--dry-run` | **NEW in v4.0.1** Preview changes without modifying files |
+| `--skills-only` | Install skills only, skip project scanning |
+| `--scan-only` | Install base config + project scan (skips skills/MCP — NOT a dry-run, see `--dry-run`) |
+| `--verbose` | Enable verbose output |
+| `--no-external` | Skip external skill installations (npm) |
+| `--no-mcp` | Skip MCP installations |
+| `--no-github` | Skip GitHub authentication |
+| `--non-interactive`, `--yes`, `-y` | Skip ALL prompts (use defaults) |
+| `--github-token TOKEN` | Provide GitHub PAT |
+| `--gemini-key KEY` | Provide Gemini API key |
+| `--update` | Re-copy skills, regenerate commands, update settings.json |
+
+---
+
+## Troubleshooting
+
+### `bash: install.sh: Permission denied`
+```bash
+chmod +x /tmp/dee-install/install.sh
+bash /tmp/dee-install/install.sh /path/to/project
+```
+
+### `python3: command not found` (macOS)
+```bash
+brew install python3
+# or use full path:
+which python3
+```
+
+### Windows: `UnicodeEncodeError` during install
+**Fixed in v4.0.1.** Update DEE:
+```bash
+cd /path/to/devlmer-ecosystem-engine
+git pull origin main
+```
+
+### `--scan-only` modifies my project (expected dry-run)
+**Fixed in v4.0.1.** Use `--dry-run` instead:
+```bash
+bash install.sh /path/to/project --dry-run
+```
+
+### My API key got committed by accident
+**Fixed in v4.0.1.** Update DEE — `.gitignore` now covers config files.
+
+If you committed a key:
+1. Rotate the key immediately at the provider's console
+2. Use [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or `git-filter-repo` to remove from history
+3. Force-push to overwrite remote (coordinate with team)
+
+### Hooks not running on Windows
+**Fixed in v4.0.1.** Hooks now use Python stdlib for cross-platform compatibility. Update DEE.
+
+### "Domain: unknown" in banner / wrong tech detection
+Known issue (#30). The fingerprinter sometimes misclassifies. Workaround: regenerate profile manually:
+```bash
+cd /path/to/your/project
+python3 .claude/detect_project.py "$(pwd)" > .claude/PROJECT_PROFILE.json
+```
+
+---
+
+## Uninstall DEE
+
+To remove DEE from a project:
+
+```bash
+cd /path/to/your/project
+
+# Backup first (just in case)
+cp -r .claude .claude.backup-$(date +%Y%m%d)
+cp CLAUDE.md CLAUDE.md.backup
+
+# Remove DEE artifacts
+rm -rf .claude
+rm -f CLAUDE.md
+rm -f .deeignore
+
+# Restore your CLAUDE.md (optional, if you had one before DEE)
+mv CLAUDE.md.backup CLAUDE.md
+```
+
+DEE never modifies your project's source code, so removing `.claude/` is safe.
+
+---
+
+## Verify installation success
+
+Run this command in your DEE-installed project:
+
+```bash
+ls -la .claude/
+```
+
+You should see:
+```
+.claude/
+├── agents/         (agent definitions)
+├── commands/       (26 slash commands)
+├── config/         (4 config files)
+├── hooks/          (3 hooks)
+├── skills/         (25 skills)
+├── settings.json   (Claude Code config)
+└── PROJECT_PROFILE.json  (auto-generated)
+```
+
+If all directories exist, DEE is correctly installed.
+
+---
+
+## Get help
+
+- 📚 Full documentation: [README.md](README.md)
+- 🎧 Audio/video tutorial: [docs/notebooklm/](docs/notebooklm/) (generate your own with NotebookLM)
+- 🐛 Report bugs: [GitHub Issues](https://github.com/Soyelijah/devlmer-ecosystem-engine/issues)
+- 💬 Discussions: [GitHub Discussions](https://github.com/Soyelijah/devlmer-ecosystem-engine/discussions)
+- 🌐 Website: [devlmer.com](https://devlmer.com)
+
+---
+
+## What's new in v4.0.1
+
+- 🔒 **Security:** API key configs now gitignored by default (#26)
+- 🪟 **Windows:** No more `UnicodeEncodeError` during install (#24)
+- 🛠️ **DX:** New `--dry-run` flag for safe previews (#25)
+
+See [CHANGELOG.md](CHANGELOG.md) for full release notes.
+
+---
+
+**Built with ❤️ by [@Soyelijah](https://github.com/Soyelijah) — Devlmer**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Intelligent Ecosystems for Every Project
 
-[![Version](https://img.shields.io/badge/version-4.0.0-0052FF?style=for-the-badge&logo=semver&logoColor=white)](https://github.com/Soyelijah/devlmer-ecosystem-engine/releases/tag/v4.0.0)
+[![Version](https://img.shields.io/badge/version-4.0.1-0052FF?style=for-the-badge&logo=semver&logoColor=white)](https://github.com/Soyelijah/devlmer-ecosystem-engine/releases/tag/v4.0.1)
 [![License](https://img.shields.io/badge/license-MIT-00D4AA?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](https://github.com/Soyelijah/devlmer-ecosystem-engine/blob/main/LICENSE)
 [![Skills](https://img.shields.io/badge/skills-64-FF6B35?style=for-the-badge&logo=stackblitz&logoColor=white)](https://github.com/Soyelijah/devlmer-ecosystem-engine/tree/main/skills)
 [![Domains](https://img.shields.io/badge/domains-22-8B5CF6?style=for-the-badge&logo=target&logoColor=white)](https://github.com/Soyelijah/devlmer-ecosystem-engine/blob/main/blueprints/ecosystems.json)
@@ -21,10 +21,26 @@
 
 | | |
 |---|---|
-| **Versión** | 4.0.0 — Enterprise Complete |
+| **Versión** | 4.0.1 — Windows + Security Hardening |
 | **Autor** | Pierre Solier (Devlmer) |
 | **Licencia** | [MIT](https://github.com/Soyelijah/devlmer-ecosystem-engine/blob/main/LICENSE) |
 | **Última actualización** | Mayo 2026 |
+
+---
+
+<div align="center">
+
+## 🚀 Quick Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/install-cli.sh | bash
+```
+
+**📖 Full installation guide → [INSTALL.md](INSTALL.md)**
+
+*Choose from 4 install methods · Windows / macOS / Linux · 30 seconds · v4.0.1*
+
+</div>
 
 ---
 

--- a/docs/notebooklm/HOW_TO_GENERATE.md
+++ b/docs/notebooklm/HOW_TO_GENERATE.md
@@ -1,0 +1,258 @@
+# How to generate DEE tutorial video/audio with NotebookLM
+
+> Step-by-step guide to use Google NotebookLM to produce a podcast/video tutorial about installing and using Devlmer Ecosystem Engine.
+
+---
+
+## What is NotebookLM?
+
+[NotebookLM](https://notebooklm.google.com) is Google's AI-powered notebook tool. You upload sources (documents, links, videos), and it generates AI-narrated summaries — including a feature called **"Audio Overview"** that produces a 10-minute podcast with two AI hosts discussing your sources naturally.
+
+**Result:** professional-sounding podcast/video with two hosts explaining DEE, ready to share on YouTube, social media, or your website.
+
+---
+
+## Step-by-step generation guide
+
+### Prerequisites
+
+- Google account (any free Gmail works)
+- Web browser (Chrome recommended)
+- Approximately 15 minutes total
+
+---
+
+### Step 1 — Open NotebookLM
+
+1. Go to https://notebooklm.google.com
+2. Sign in with your Google account
+3. Click **"Create new notebook"** (top right)
+
+---
+
+### Step 2 — Add sources
+
+NotebookLM works by reading sources you provide. For DEE, upload these in order:
+
+**Required sources (upload these):**
+
+1. **README.md** from DEE repo
+   - URL: https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/README.md
+   - Or: Copy from your local clone at `Desktop/projects_qwen/devlmer-ecosystem-engine/README.md`
+   - In NotebookLM: click **"Add source"** → **"Paste text"** or **"Website URL"**
+
+2. **INSTALL.md** from DEE repo
+   - URL: https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/INSTALL.md
+   - The new comprehensive install guide
+
+3. **CHANGELOG.md** from DEE repo
+   - URL: https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/CHANGELOG.md
+   - Includes v4.0.1 release notes
+
+4. **SCRIPT_NARRATIVE.md** (this kit)
+   - From `docs/notebooklm/SCRIPT_NARRATIVE.md` in the repo
+   - This is the "creative direction" for the AI — it follows the conversational flow we want
+
+**Optional sources (improve depth):**
+
+5. GitHub releases page: https://github.com/Soyelijah/devlmer-ecosystem-engine/releases
+6. Issue #24, #25, #26 (closed) — for context on v4.0.1 fixes
+
+**Tip:** NotebookLM can handle up to 50 sources. Don't overload — 4 to 6 well-chosen sources work better than 20 random ones.
+
+---
+
+### Step 3 — Customize the audio overview
+
+After uploading sources:
+
+1. In the **Studio** panel (right side), find **"Audio Overview"**
+2. Click **"Customize"** (next to the Generate button)
+3. Paste this guidance prompt:
+
+```
+Generate a podcast-style audio overview targeting non-technical users who are
+curious about Devlmer Ecosystem Engine (DEE). Two hosts having a natural
+conversation. One host is a curious newcomer asking practical questions about
+installation, security, and usage. The other host is knowledgeable and
+explains in accessible language. Length: 8-12 minutes. Cover:
+
+1. What DEE is and what it does (skills, commands, hooks, MCPs)
+2. The 4 installation methods, when to use each
+3. The new --dry-run feature in v4.0.1 for safe previews
+4. Security: API keys are now gitignored automatically (v4.0.1)
+5. Post-install commands: /dee-doctor, /dee-status, /dee-demo
+6. How to update an existing installation
+7. How to contribute on GitHub
+
+Tone: friendly, professional, accessible. Avoid corporate jargon.
+End with a clear call to action: visit github.com/Soyelijah/devlmer-ecosystem-engine.
+
+Reference the SCRIPT_NARRATIVE.md document I uploaded for the conversational
+flow and key talking points. Use it as creative direction, not verbatim.
+```
+
+4. Click **"Generate"**
+5. Wait 2–5 minutes (NotebookLM generates the audio)
+
+---
+
+### Step 4 — Review and iterate
+
+When the audio is ready:
+
+1. Click play and listen all the way through
+2. Check for:
+   - ✅ Accuracy (DEE features, install commands, version numbers)
+   - ✅ Pacing (not too fast, not too slow)
+   - ✅ Tone (conversational, not robotic)
+   - ✅ Call to action at the end
+3. If something's off, click **"Customize"** again, refine the prompt, regenerate
+
+**Common refinements:**
+
+- "Make it shorter, around 8 minutes"
+- "More energy in the first minute"
+- "Less technical jargon"
+- "Emphasize the v4.0.1 security fix more"
+
+---
+
+### Step 5 — Download the audio
+
+Once happy:
+
+1. Click the **three-dot menu** on the audio overview
+2. Select **"Download"**
+3. Save as `dee-installation-tutorial.wav` (or `.mp3`)
+
+---
+
+### Step 6 — Convert audio to video (optional)
+
+To publish on YouTube/social media as video:
+
+**Option A — Easiest: with a static image**
+
+```bash
+# Use ffmpeg (free, cross-platform)
+ffmpeg -loop 1 -i cover.png -i dee-installation-tutorial.wav \
+  -c:v libx264 -tune stillimage -c:a aac -b:a 192k -pix_fmt yuv420p \
+  -shortest dee-installation-tutorial.mp4
+```
+
+Where `cover.png` is a logo image (e.g., DEE banner, 1920×1080).
+
+**Option B — Animated waveform: use [Headliner](https://headliner.app/)**
+
+1. Free service, sign up
+2. Upload audio
+3. Choose template (waveform animation, captions, branding)
+4. Export as MP4
+
+**Option C — Professional: hire video editor**
+
+- Add captions, B-roll, animations
+- Sync to key talking points
+- Deliver as YouTube-ready MP4
+
+---
+
+### Step 7 — Publish
+
+**Where to share:**
+
+- **YouTube** — full video, public, listed under "Programming Tutorials"
+- **GitHub** — link the video from README.md and INSTALL.md
+- **Twitter/X** — short clip + link to full video
+- **LinkedIn** — professional version
+- **Devlmer.com** — embed on landing page
+
+**Suggested video metadata:**
+
+- **Title:** "Install Devlmer Ecosystem Engine in 60 seconds — DEE v4.0.1 walkthrough"
+- **Description:** Include link to GitHub repo, INSTALL.md, and Devlmer.com
+- **Tags:** `claude-code`, `cowork`, `ai-tools`, `developer-tools`, `git`, `bash`, `installation`, `tutorial`
+- **Thumbnail:** DEE logo + "Install in 60s" text
+
+---
+
+## Quality checklist before publishing
+
+Before sharing publicly, verify:
+
+- [ ] Audio is clear, no glitches
+- [ ] Hosts pronounce "Devlmer Ecosystem Engine" correctly
+- [ ] Install commands are accurate (especially the curl one-liner)
+- [ ] Version 4.0.1 is mentioned
+- [ ] No misleading claims about features
+- [ ] GitHub URL is correct
+- [ ] Length is between 8-12 minutes (sweet spot for engagement)
+- [ ] CTA at the end is clear
+
+---
+
+## Iterating with new releases
+
+When DEE releases new versions:
+
+1. Update `SCRIPT_NARRATIVE.md` with new features
+2. Update `CHANGELOG.md` reference
+3. Re-run NotebookLM with same prompt
+4. Generate new audio overview
+5. Replace old video on YouTube with new version (or upload as v4.0.2 tutorial)
+
+NotebookLM keeps your notebook for re-runs, so you don't have to re-upload sources every time.
+
+---
+
+## Troubleshooting
+
+### "Audio overview is too generic"
+
+Add more specific guidance to the prompt:
+
+```
+Cover SPECIFICALLY these points: [list 5-7 bullet points]
+Use the conversational style from SCRIPT_NARRATIVE.md.
+Mention version v4.0.1 multiple times.
+```
+
+### "Hosts are too formal"
+
+Add: "Make the conversation casual and natural. The newcomer host should ask follow-up questions like a real person would."
+
+### "Audio is too long"
+
+Add: "Target 8 minutes maximum. Cover the most important 5 points only."
+
+### "It mispronounces 'Devlmer'"
+
+Currently NotebookLM may pronounce it as "Devalmer" or "Develmer". You can:
+1. Add to prompt: "Pronounce 'Devlmer' as DEV-luh-mur"
+2. Or accept the variant and clarify in video description
+
+---
+
+## Cost
+
+- **NotebookLM:** Free (currently)
+- **YouTube hosting:** Free
+- **Headliner waveform:** Free tier with watermark, $14/mo unlimited
+- **ffmpeg approach:** Free, no watermark
+
+Total cost to produce: $0 if you use ffmpeg + free tier tools.
+
+---
+
+## Done!
+
+You now have a professional podcast/video tutorial for DEE that:
+
+✅ Reaches non-technical users
+✅ Covers all 4 install methods
+✅ Explains v4.0.1 security improvements
+✅ Generated automatically from your existing docs
+✅ Can be regenerated on every release without manual scripting
+
+**Next:** add the YouTube link to README.md so visitors can watch before installing.

--- a/docs/notebooklm/README.md
+++ b/docs/notebooklm/README.md
@@ -1,0 +1,87 @@
+# DEE NotebookLM Kit
+
+Generate professional installation tutorials (audio podcast or video) for Devlmer Ecosystem Engine using Google's NotebookLM.
+
+---
+
+## What's in this directory
+
+| File | Purpose |
+|---|---|
+| **[HOW_TO_GENERATE.md](HOW_TO_GENERATE.md)** | Step-by-step walkthrough: open NotebookLM → upload sources → generate audio → publish |
+| **[SOURCES.md](SOURCES.md)** | Curated list of 8 sources to upload to NotebookLM (in priority order) |
+| **[SCRIPT_NARRATIVE.md](SCRIPT_NARRATIVE.md)** | Pre-written conversational script for two-host podcast format |
+
+---
+
+## Quick start
+
+1. Open https://notebooklm.google.com and sign in
+2. Create a new notebook
+3. Upload the 8 sources listed in [SOURCES.md](SOURCES.md)
+4. Click "Audio Overview" → "Customize"
+5. Paste the prompt from [HOW_TO_GENERATE.md](HOW_TO_GENERATE.md) Step 3
+6. Click Generate, wait 2–5 minutes
+7. Download the audio
+8. (Optional) Convert to video with ffmpeg or Headliner
+9. Publish to YouTube + link from README.md
+
+**Total time:** ~15 minutes from zero to published tutorial.
+
+---
+
+## Why NotebookLM?
+
+- ✅ **Free** (currently)
+- ✅ **AI-narrated** in natural conversational style
+- ✅ **Two-host podcast format** sounds like a real interview, not a robot reading docs
+- ✅ **Auto-generates** from your existing docs (no manual scripting)
+- ✅ **Re-runnable** when DEE releases new versions
+- ✅ **Cross-platform** access (any browser)
+
+---
+
+## Updating tutorials when DEE evolves
+
+When v4.0.2 or v4.1.0 releases:
+
+1. Update `SCRIPT_NARRATIVE.md` in this directory with new features
+2. Update `CHANGELOG.md` references
+3. Open existing NotebookLM notebook (your sources stay)
+4. Click "Refresh sources"
+5. Re-generate Audio Overview
+6. Replace YouTube video with new version
+
+NotebookLM remembers your prompts, so consistent style across releases.
+
+---
+
+## Production-quality output
+
+For a professional video that goes on YouTube + Devlmer.com landing:
+
+1. Generate base audio with NotebookLM (this kit)
+2. Process audio with [Adobe Podcast](https://podcast.adobe.com/) (free) for noise reduction
+3. Create branded waveform with [Headliner](https://headliner.app/) ($14/mo unlimited)
+4. Add captions with YouTube Studio auto-caption
+5. Publish
+
+Estimated total cost: $0–$14/mo depending on tools used.
+
+---
+
+## Audience
+
+The generated tutorial is designed to reach:
+
+- 🌟 **Developers** evaluating AI-assisted tools
+- 🌟 **DevOps engineers** considering ecosystem-wide automation
+- 🌟 **Tech leads** looking for team-wide AI infrastructure
+- 🌟 **Solopreneurs** building products with Claude Code/Cowork
+- 🌟 **Indie hackers** wanting professional dev workflows
+
+The script is calibrated for someone who has heard of Claude Code/Cowork but doesn't know DEE specifically.
+
+---
+
+**Maintained by:** [@Soyelijah](https://github.com/Soyelijah) — Devlmer

--- a/docs/notebooklm/SCRIPT_NARRATIVE.md
+++ b/docs/notebooklm/SCRIPT_NARRATIVE.md
@@ -1,0 +1,183 @@
+# DEE NotebookLM Narrative Script
+
+> Conversational script designed for NotebookLM to generate an engaging podcast/video about installing and using Devlmer Ecosystem Engine. Optimized for natural two-host dialogue.
+
+---
+
+## Audio target: 8–12 minutes
+
+## Tone: friendly, professional, accessible to non-technical users while still informative for developers
+
+## Suggested hosts: Host A (curious newcomer), Host B (knowledgeable explainer)
+
+---
+
+## SECTION 1 — Hook (0:00 – 0:45)
+
+**Host A:** "So I've been hearing about this thing called DEE — Devlmer Ecosystem Engine. Apparently it's supposed to make Claude Code, like, way more powerful?"
+
+**Host B:** "Yeah! It's actually pretty cool. The basic idea is: any project you're working on — a React app, a Python backend, a mobile app, whatever — DEE detects what stack you're using and automatically installs the right toolset for that stack."
+
+**Host A:** "Like what? Templates?"
+
+**Host B:** "More than templates. It installs 64 specialized AI skills, 26 slash commands, hooks that run automatically when you save files, and it figures out which Model Context Protocol servers — MCPs — your project needs. All in one command."
+
+**Host A:** "One command? In any project?"
+
+**Host B:** "One command. Let me walk you through it."
+
+---
+
+## SECTION 2 — What DEE actually does (0:45 – 2:30)
+
+**Host A:** "OK before we get to install, what does DEE actually give you?"
+
+**Host B:** "Three big things. First — it analyzes your project. It looks at your `package.json`, your file structure, your dependencies, and it figures out: this is a React app with Tailwind, or this is a Django backend with PostgreSQL, or this is a POS system in PHP."
+
+**Host A:** "How accurate is that?"
+
+**Host B:** "Pretty good. It has signatures for 80+ technologies and 18 different business domains. It even gives you a confidence score per detection."
+
+**Host A:** "OK so it knows what you're working on. Then what?"
+
+**Host B:** "Then it loads the right skills. So if you're building a React app, it activates skills like 'senior-frontend' and 'tailwind-patterns' and 'ui-design-system'. If you're doing security work, it loads 'senior-security'. The AI knows when to use each one because each skill has triggers — patterns of what you're asking — that activate them automatically."
+
+**Host A:** "So I don't have to manually pick which skill to use?"
+
+**Host B:** "Exactly. You just write code, and the right skill activates when relevant. Plus you get slash commands like /dee-doctor that runs a health check, /dee-status that shows your dashboard, /senior-architect that gives you architecture guidance. All available in your project."
+
+**Host A:** "And the third thing?"
+
+**Host B:** "Hooks. Background automation. Every time you save a file, DEE can run quality checks. When you start a session, you get a banner showing what's loaded. When you stop a session, it can auto-save your progress. You don't see the work, but it's happening continuously."
+
+---
+
+## SECTION 3 — How to install (2:30 – 5:30)
+
+**Host A:** "OK I'm sold. How do I install it?"
+
+**Host B:** "You have four options, depending on who you are. If you're new and just want to try it, you do this single command:"
+
+**Host A:** "Hit me."
+
+**Host B:** "`curl -fsSL https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/install-cli.sh | bash`"
+
+**Host A:** "Wait, that's literally one line?"
+
+**Host B:** "One line. It downloads a small bootstrap script, which then clones DEE temporarily, asks you a few questions about your project, and installs everything. Takes maybe 30 to 60 seconds total."
+
+**Host A:** "What if I'm a developer who wants more control?"
+
+**Host B:** "Then method two. Clone the repo manually, then point the installer at your project."
+
+**Host A:** "Show me."
+
+**Host B:** "OK so first: `git clone https://github.com/Soyelijah/devlmer-ecosystem-engine.git /tmp/dee-install`. That puts DEE in a temporary folder. Then: `bash /tmp/dee-install/install.sh /path/to/your/project`. That runs the installer pointing at YOUR project, not the temp folder."
+
+**Host A:** "What if I don't have Git? Like on a Windows machine without it installed?"
+
+**Host B:** "That's method three. You just download the repo as a ZIP file using curl, unzip it, and run the installer from the unzipped folder. Same end result, different way to get there."
+
+**Host A:** "Now this is where I get nervous — what if I install it and don't like what it does?"
+
+**Host B:** "Method four. The dry-run flag. This is new in version 4.0.1."
+
+**Host A:** "What does dry-run mean?"
+
+**Host B:** "It means: tell me exactly what you WOULD do, without actually doing anything. Run `bash install.sh /path/to/project --dry-run` and DEE will print every file it would create, every file it would modify, every directory it would set up. Total preview. Zero changes to your project."
+
+**Host A:** "That's... that's actually amazing. So I can preview, then if I like it, run for real."
+
+**Host B:** "Exactly. Safe by default."
+
+---
+
+## SECTION 4 — Real-world security (5:30 – 7:00)
+
+**Host A:** "Speaking of safe — what about API keys? DEE uses Gemini for image generation, right?"
+
+**Host B:** "Right. And here's a story about that. In version 4.0.1 we just released a critical security fix. Before that, when you set your Gemini API key, the file containing it wasn't gitignored. Which means if you ran `git add .` after installing, you could accidentally commit your API key to your public repo."
+
+**Host A:** "Yikes."
+
+**Host B:** "Yeah. So in 4.0.1 we added all the API key configs to gitignore by default. Plus we added template files — like `nano-banana-config.template.json` — which are safe to commit and just have empty placeholders for keys."
+
+**Host A:** "So now after install, I'm protected automatically?"
+
+**Host B:** "Mostly. There's still one thing you should do manually — and we recommend this in the post-install checklist — add the configs to your project's gitignore too. Just to be extra safe. We have a copy-paste block in the INSTALL guide that does it for you."
+
+**Host A:** "What if someone already accidentally committed their key?"
+
+**Host B:** "Rotate it immediately. That's the only way. Once a key is in git history, it's basically public. Most providers — Gemini, GitHub, OpenAI — let you revoke and regenerate keys instantly. Then you fix gitignore, then you remove from history with a tool like BFG Repo-Cleaner."
+
+---
+
+## SECTION 5 — After install (7:00 – 9:00)
+
+**Host A:** "OK installation is done. What do I do first?"
+
+**Host B:** "Run /dee-doctor. It's a slash command. You type it in Claude Code or Cowork, and it runs a full health check. Verifies all skills loaded correctly, all hooks are active, all configs valid, your environment is good."
+
+**Host A:** "Like a system check?"
+
+**Host B:** "Exactly. It tells you green, yellow, or red on every component. If something's wrong, it tells you exactly what and how to fix it."
+
+**Host A:** "What else?"
+
+**Host B:** "/dee-status shows you a dashboard. How many skills loaded, how many commands available, what MCPs are connected, what your project type was detected as."
+
+**Host A:** "And /dee-demo?"
+
+**Host B:** "Interactive tour. Walks you through what's installed using your real project data. Not a generic tutorial — actually demonstrates what DEE knows about YOUR codebase."
+
+**Host A:** "OK what about the senior skills? You mentioned senior-architect, senior-backend..."
+
+**Host B:** "Those are specialized AI personas. When you invoke /senior-backend, the AI takes on the perspective of a senior backend engineer reviewing your code. /senior-security does threat modeling. /senior-frontend gives you UI/UX guidance. Each one is calibrated for serious professional work — not surface-level advice."
+
+---
+
+## SECTION 6 — Updates and contribution (9:00 – 10:30)
+
+**Host A:** "What if DEE gets updated? Do I have to reinstall?"
+
+**Host B:** "There's an update.sh script. You pull the latest DEE repo, then run `bash update.sh /path/to/your/project`. It backs up your local config first, then updates skills, commands, hooks, and scripts. Your customizations are preserved."
+
+**Host A:** "What about contributing? Like if I find a bug?"
+
+**Host B:** "DEE is open source on GitHub. The repo is `Soyelijah/devlmer-ecosystem-engine`. Issues are open. Pull requests welcome. Pierre Solier — the creator — actively maintains it."
+
+**Host A:** "Anyone can submit improvements?"
+
+**Host B:** "Absolutely. The repo has clear contribution guidelines, plus the entire roadmap is in GitHub Issues. You can pick an issue tagged 'good first issue' and dive in."
+
+---
+
+## SECTION 7 — Wrap-up (10:30 – 12:00)
+
+**Host A:** "OK so let me summarize. DEE is a tool that auto-detects your project type and installs everything you need to work professionally with Claude Code. One command to install. Four methods depending on your setup. Skills, commands, hooks, and AI personas all activated automatically based on what you're working on."
+
+**Host B:** "Plus it's safe by default with the new dry-run mode and gitignore protection in 4.0.1."
+
+**Host A:** "What's the call to action for someone watching this?"
+
+**Host B:** "Three steps. One — go to github.com/Soyelijah/devlmer-ecosystem-engine. Two — read the INSTALL.md file. Three — pick the install method that fits your platform and run it. Takes a minute."
+
+**Host A:** "And if they like it?"
+
+**Host B:** "Star the repo on GitHub. Submit feedback as an issue. If you build something interesting with it, share it. The whole point is to make professional-quality AI-assisted development accessible to everyone, regardless of stack."
+
+**Host A:** "Devlmer Ecosystem Engine. Version 4.0.1. Available now. github.com/Soyelijah/devlmer-ecosystem-engine."
+
+**Host B:** "Try it. You'll see the difference in your next coding session."
+
+---
+
+## End
+
+## Production notes for NotebookLM
+
+- **Tone:** conversational, no corporate jargon
+- **Pacing:** moderate, allow natural pauses
+- **Emphasis:** v4.0.1 fixes (security, Windows, dry-run) are recent and important — give them time
+- **Audience:** assume listener has heard of Claude Code/Cowork but doesn't know DEE
+- **CTA:** GitHub repo link at the end, twice for memorability

--- a/docs/notebooklm/SOURCES.md
+++ b/docs/notebooklm/SOURCES.md
@@ -1,0 +1,129 @@
+# NotebookLM Sources for DEE Tutorial Generation
+
+> Curated list of sources to upload to NotebookLM for generating the DEE installation tutorial podcast/video. Listed in priority order.
+
+---
+
+## Required sources (upload these in this order)
+
+### 1. INSTALL.md — Primary source
+- **Path:** `INSTALL.md` (root of repo)
+- **URL:** https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/INSTALL.md
+- **Why:** Comprehensive installation guide with 4 methods, requirements, troubleshooting
+- **NotebookLM tip:** Upload as "Website URL" so it stays current with future updates
+
+### 2. README.md — Project context
+- **Path:** `README.md` (root of repo)
+- **URL:** https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/README.md
+- **Why:** What DEE is, who it's for, what it includes (skills, MCPs, hooks)
+
+### 3. CHANGELOG.md — Release context
+- **Path:** `CHANGELOG.md` (root of repo)
+- **URL:** https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/CHANGELOG.md
+- **Why:** v4.0.1 changes (Windows fixes, security hardening, dry-run flag)
+
+### 4. SCRIPT_NARRATIVE.md — Creative direction
+- **Path:** `docs/notebooklm/SCRIPT_NARRATIVE.md`
+- **Why:** Pre-written conversational script in two-host format. NotebookLM uses this as the structural template for the audio overview
+
+---
+
+## Recommended sources (improve depth)
+
+### 5. Issue #26 — Security fix context
+- **URL:** https://github.com/Soyelijah/devlmer-ecosystem-engine/issues/26
+- **Why:** Detailed explanation of the API key gitignore fix in v4.0.1
+
+### 6. Issue #24 — Windows compatibility fix
+- **URL:** https://github.com/Soyelijah/devlmer-ecosystem-engine/issues/24
+- **Why:** Context on the UnicodeEncodeError fix in v4.0.1
+
+### 7. Issue #25 — Dry-run feature context
+- **URL:** https://github.com/Soyelijah/devlmer-ecosystem-engine/issues/25
+- **Why:** Why `--dry-run` was added in v4.0.1
+
+### 8. GitHub Releases page
+- **URL:** https://github.com/Soyelijah/devlmer-ecosystem-engine/releases
+- **Why:** Official release notes, version history
+
+---
+
+## Optional sources (for advanced versions)
+
+### 9. .env.example — Security pattern
+- **URL:** https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/.env.example
+- **Why:** Shows the safe-to-commit template approach for API keys
+
+### 10. install.sh source code (advanced viewers)
+- **URL:** https://raw.githubusercontent.com/Soyelijah/devlmer-ecosystem-engine/main/install.sh
+- **Why:** Power users may want to peek at what the installer actually does
+
+---
+
+## Sources to AVOID uploading
+
+These would dilute the tutorial focus:
+
+- ❌ Skills directory contents (too detailed for tutorial)
+- ❌ Internal scripts (`scripts/detect_project.py`, etc.)
+- ❌ Old DIAGNOSIS.md (historical context, not actionable)
+- ❌ Closed issues unrelated to v4.0.1
+- ❌ License/contributing files (administrative)
+
+---
+
+## Total sources: 4 required + 4 recommended = **8 sources**
+
+NotebookLM works best with focused, high-quality sources. 8 well-chosen sources produce better audio than 30 random ones.
+
+---
+
+## Source upload order in NotebookLM
+
+When uploading, do them in this exact order so NotebookLM weights them correctly:
+
+```
+1. INSTALL.md        ← primary install reference
+2. SCRIPT_NARRATIVE.md ← creative direction
+3. README.md         ← project context
+4. CHANGELOG.md      ← v4.0.1 specifics
+5. Issue #26         ← security context
+6. Issue #24         ← Windows fix context
+7. Issue #25         ← dry-run context
+8. GitHub Releases   ← official release notes
+```
+
+NotebookLM treats earlier sources as more authoritative.
+
+---
+
+## Refresh strategy
+
+When DEE releases a new version:
+
+1. Update `INSTALL.md` and `CHANGELOG.md` in the repo
+2. Update version numbers in `SCRIPT_NARRATIVE.md`
+3. Open NotebookLM, click "Refresh" on each source
+4. Regenerate Audio Overview with same prompt
+5. Result: updated tutorial reflecting the new version automatically
+
+This avoids re-recording videos manually for every release.
+
+---
+
+## Generated artifacts naming convention
+
+When you produce videos from these sources, suggested naming:
+
+- **v4.0.1 tutorial:** `dee-tutorial-v4.0.1-installation.mp4`
+- **Quick install:** `dee-quickstart-v4.0.1-60s.mp4`
+- **Security focus:** `dee-security-v4.0.1.mp4`
+
+This makes them findable later when DEE evolves to v5.0.
+
+---
+
+## See also
+
+- [HOW_TO_GENERATE.md](HOW_TO_GENERATE.md) — step-by-step NotebookLM walkthrough
+- [SCRIPT_NARRATIVE.md](SCRIPT_NARRATIVE.md) — conversational script template


### PR DESCRIPTION
## Summary

Documentation improvements covering 3 audiences for the v4.0.1 release:

1. **CEO/Maintainer** — clone master workflow, update.sh
2. **External developers** — 4 install methods, troubleshooting, full flag reference
3. **Non-technical users** — NotebookLM kit to generate audio/video tutorials

## Files changed

### New files
- `INSTALL.md` (353 lines) — comprehensive installation guide
- `docs/notebooklm/README.md` (87 lines) — kit overview
- `docs/notebooklm/HOW_TO_GENERATE.md` (258 lines) — step-by-step NotebookLM walkthrough
- `docs/notebooklm/SOURCES.md` (129 lines) — curated source list
- `docs/notebooklm/SCRIPT_NARRATIVE.md` (183 lines) — two-host podcast script

### Modified
- `README.md` — version bumped to 4.0.1, added Quick Install banner

## INSTALL.md highlights

- 4 install methods comparison table with platform/time/audience
- Method 1: curl one-liner (recommended)
- Method 2: git clone (developers)
- Method 3: ZIP download (Windows without Git)
- Method 4: --dry-run preview (cautious users — NEW in v4.0.1)
- Requirements with platform-specific install commands
- Post-install security checklist
- First-time setup walkthrough
- Update procedure with update.sh
- Full flag reference table
- Troubleshooting section (covers v4.0.1 fixes for #24, #25, #26)
- Uninstall procedure

## NotebookLM kit highlights

- Step-by-step guide to use Google NotebookLM (free)
- Pre-written conversational script for two-host podcast format
- Curated source list (8 sources in priority order)
- Refresh strategy for future DEE releases (no manual re-recording)
- Production-quality output workflow (Adobe Podcast + Headliner + YouTube)
- Estimated total cost: $0–$14/mo

## Why NotebookLM?

NotebookLM generates AI-narrated podcast audio from uploaded sources. Two AI hosts have natural conversation about the topic. Output sounds professional without manual scripting/recording.

For DEE, this means: every release can have a fresh tutorial in ~15 minutes by re-running NotebookLM with updated CHANGELOG.md.

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] Internal links resolve (INSTALL.md → docs/notebooklm/, etc.)
- [x] Banner badges in README.md show v4.0.1
- [x] All install commands verified against actual install.sh in main
- [x] NotebookLM workflow steps tested (manual verification of UI flow)