### PR TITLE
fix(detection): exclude .agents/ from project scan + add .deeignore support (#30)

### DIFF
--- a/scripts/detect_project.py
+++ b/scripts/detect_project.py
@@ -479,16 +479,29 @@ class ProjectFingerprinter:
             "target", ".gradle", ".idea", ".vscode", ".turbo",
             ".output", ".svelte-kit", ".vercel", ".netlify",
             "android/build", "ios/Pods", ".dart_tool",
-            # DEE self-contamination exclusions (Issue #21)
-            ".claude", ".dee", "devlmer-ecosystem-engine",
+            # DEE self-contamination exclusions (Issues #21, #30)
+            ".claude", ".dee", ".agents", "devlmer-ecosystem-engine",
         }
+
+        # Issue #30 — also load user-defined exclusions from .deeignore
+        deeignore_path = os.path.join(self.root, ".deeignore")
+        if os.path.isfile(deeignore_path):
+            try:
+                with open(deeignore_path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line and not line.startswith("#"):
+                            skip.add(line)
+            except (IOError, OSError):
+                pass
+
         for dirpath, dirnames, filenames in os.walk(self.root):
             # Filter by name-level skip list
             dirnames[:] = [d for d in dirnames if d not in skip]
             rel_dir = os.path.relpath(dirpath, self.root)
-            # Also skip the `skills` directory when it lives inside `.claude`
-            # to prevent DEE skill files from contaminating domain detection
-            if rel_dir.startswith(".claude"):
+            # Also skip the `skills` directory when it lives inside .claude / .agents / .dee
+            # to prevent DEE skill files from contaminating domain detection (#21, #30)
+            if rel_dir.startswith((".claude", ".agents", ".dee")):
                 dirnames[:] = [d for d in dirnames if d != "skills"]
             self.dirs.append(rel_dir)
             for fn in filenames:


### PR DESCRIPTION
Closes #30

## Summary
Issue #21 added `.claude`, `.dee`, and `devlmer-ecosystem-engine` to the directory exclusion set in `detect_project.py`. This fix extends the exclusions to cover `.agents/` (used by some Claude Code setups) and adds support for user-defined `.deeignore` files.

## Changes
1. Add `.agents` to default exclusion set
2. Skip `skills/` subdirectory inside `.agents/` and `.dee/` (extending existing `.claude/` skip)
3. Read `.deeignore` file at project root if present — one directory per line, # comments allowed

## Why
Real-world reproduction (SYSME-POS, PHP/MariaDB POS):
- Has legacy `.agents/skills/firebase-*/` directories from past Firebase experiments
- detect_project.py incorrectly classified the project as 67% Firebase / Domain ecommerce

## Testing
```bash
# Before fix:
python3 detect_project.py /path/to/php-project | grep technologies
# {firebase: 0.67, jest: 0.33}  ← WRONG

# After fix:
# .agents/skills/firebase-* directories no longer counted
# Combined with user-defined .deeignore, the user can exclude
# any additional directories (e.g. legacy experiments)
```

## Backward compatibility
- Existing projects: no breaking change
- `.deeignore` is optional
- Adding `.agents` only REMOVES false positives, never adds them

## Related
- Issue #21 — original auto-contamination fix (closed) — limited scope
- Issue #30 — this fix extends to cover `.agents/`