### PR TITLE
fix(cli): bump bin/dee version 3.1.1 → 4.0.4 (PR #35 follow-up)

### DIFF
--- a/bin/dee
+++ b/bin/dee
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ============================================================================
-# dee — Devlmer Ecosystem Engine CLI v3.1
+# dee — Devlmer Ecosystem Engine CLI v4.0.4
 #
 # Global command for managing DEE installations.
 # Installed to ~/.local/bin/dee by the installer.
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-VERSION="3.1.1"
+VERSION="4.0.4"
 REPO_URL="https://github.com/Soyelijah/devlmer-ecosystem-engine.git"
 TMP_DIR="/tmp/dee-$$"
 


### PR DESCRIPTION
## Summary

The `bin/dee` CLI binary had its own `VERSION="3.1.1"` that was missed in PR #35 (the version sync PR).

When users run `install-cli.sh` to install the global `dee` command, the binary reports v3.1.1 even after v4.0.3 release.

## Fix
- bin/dee header comment: v3.1 → v4.0.4
- bin/dee VERSION constant: 3.1.1 → 4.0.4

## Why v4.0.4 (not v4.0.3)?
This is a follow-up patch to v4.0.3. Bumping to v4.0.4 properly reflects that this is a patch release that fixes a missed string from the v4.0.3 sync.

## Verification
```bash
$ grep VERSION bin/dee
VERSION="4.0.4"
```